### PR TITLE
Fix code scanning alert no. 1: DOM text reinterpreted as HTML

### DIFF
--- a/app/components/workbench/Preview.tsx
+++ b/app/components/workbench/Preview.tsx
@@ -3,6 +3,7 @@ import { memo, useCallback, useEffect, useRef, useState } from 'react';
 import { IconButton } from '~/components/ui/IconButton';
 import { workbenchStore } from '~/lib/stores/workbench';
 import { PortDropdown } from './PortDropdown';
+import DOMPurify from 'dompurify';
 
 type ResizeSide = 'left' | 'right' | null;
 
@@ -233,7 +234,8 @@ export const Preview = memo(() => {
             }}
             onKeyDown={(event) => {
               if (event.key === 'Enter' && validateUrl(url)) {
-                setIframeUrl(url);
+                const sanitizedUrl = DOMPurify.sanitize(url);
+                setIframeUrl(sanitizedUrl);
 
                 if (inputRef.current) {
                   inputRef.current.blur();

--- a/package.json
+++ b/package.json
@@ -97,7 +97,8 @@
     "remix-island": "^0.2.0",
     "remix-utils": "^7.7.0",
     "shiki": "^1.24.0",
-    "unist-util-visit": "^5.0.0"
+    "unist-util-visit": "^5.0.0",
+    "dompurify": "^3.2.3"
   },
   "devDependencies": {
     "@blitz/eslint-plugin": "0.1.0",


### PR DESCRIPTION
Fixes [https://github.com/ZoneCog/zone.bolt/security/code-scanning/1](https://github.com/ZoneCog/zone.bolt/security/code-scanning/1)

To fix this issue, we need to ensure that the URL provided by the user is properly sanitized before being used as the `src` attribute of the iframe. This can be achieved by using a library like `DOMPurify` to sanitize the URL. Additionally, we should ensure that the `validateUrl` function is robust enough to prevent any malicious input.

1. Install the `DOMPurify` library to sanitize the URL.
2. Update the code to sanitize the URL before setting it to `iframeUrl`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
